### PR TITLE
replace media queries vars because

### DIFF
--- a/css/components/display.css
+++ b/css/components/display.css
@@ -15,7 +15,7 @@
   display: inline;
 }
 
-@media only screen and (min-width: var(--medium)) {
+@media only screen and (min-width: 767px) {
   .none-m {
     display: none;
   }
@@ -33,7 +33,7 @@
   }
 }
 
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
   .none-l {
     display: none;
   }

--- a/css/components/flex.css
+++ b/css/components/flex.css
@@ -48,7 +48,7 @@
   float: right;
 }
 
-@media only screen and (min-width: var(--medium)) {
+@media only screen and (min-width: 767px) {
 
   .flex-m {
     display: -webkit-box;
@@ -119,7 +119,7 @@
 }
 
 
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
 
   .flex-l {
     display: -webkit-box;

--- a/css/components/grid.css
+++ b/css/components/grid.css
@@ -21,7 +21,7 @@
 .container .wrap .spaceWrap {
   padding: calc(2% + 15px) calc(2% + 15px);
 }
-@media (min-width: var(--medium)) {
+@media (min-width: 767px) {
   .container .wrap:not(.noSpaces), .container .wrap.spaceWrap,
   .container .wrap .spaceWrap {
     padding: calc(2% + 50px) calc(8% + 15px);
@@ -184,7 +184,7 @@
 
 
 /* phablet landscape and ipad portrait and > */
-@media (min-width: var(--medium)) {
+@media (min-width: 767px) {
 
   .grid > .col-m-1-1 {
     max-width: 100% !important;
@@ -207,7 +207,7 @@
   }
 }
 
-@media (min-width: var(--medium)) {
+@media (min-width: 767px) {
 
   .grid > .col-1-12 {
     max-width: 8.33333%;
@@ -420,7 +420,7 @@
   width: 66.66666666% !important;
 }
 
-@media (min-width: var(--large)) {
+@media (min-width: 980px) {
   .flex > .col-1-12 {
     width: 8.33333%;
   }
@@ -556,7 +556,7 @@
 }
 
 /* phablet landscape and ipad portrait and > */
-@media (min-width: var(--medium)) {
+@media (min-width: 767px) {
 
   .flex > .col-m-1-1 {
     width: 100% !important;

--- a/css/components/height-width.css
+++ b/css/components/height-width.css
@@ -44,13 +44,13 @@
   max-height: 100% !important;
 }
 
-@media (min-width: var(--medium)) {
+@media (min-width: 767px) {
   .h-100vh-m {
     height: 100vh;
   }
 }
 
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
   .h-100vh-l {
     height: 100vh;
   }

--- a/css/components/margin.css
+++ b/css/components/margin.css
@@ -277,7 +277,7 @@
 
 
 
-@media only screen and (min-width: var(--medium)) {
+@media only screen and (min-width: 767px) {
 
   .m-0-m {
     margin: 0;
@@ -554,7 +554,7 @@
 }
 
 
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
   .m-0-l {
     margin: 0;
   }

--- a/css/components/padding.css
+++ b/css/components/padding.css
@@ -63,7 +63,7 @@
   padding-left: 60px;
   padding-right: 60px;
 }
-@media (min-width: var(--large)) and (max-width: calc(var(--xlarge) + 1px)) {
+@media (min-width: 980px) and (max-width: calc(var(--xlarge) + 1px)) {
   .py-m-0 {
     padding-bottom: 0 !important;
     padding-top: 0 !important;
@@ -390,7 +390,7 @@
 .p-60 {
   padding: 60px;
 }
-@media only screen and (min-width: var(--medium)) {
+@media only screen and (min-width: 767px) {
   .pt-0-m {
     padding-top: 0;
   }
@@ -651,7 +651,7 @@
     padding: 60px;
   }
 }
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
   .pt-0-l {
     padding-top: 0;
   }

--- a/css/components/position.css
+++ b/css/components/position.css
@@ -25,7 +25,7 @@
   z-index: 5;
 }
 
-@media only screen and (min-width: var(--medium)) {
+@media only screen and (min-width: 767px) {
 
   .relative-m {
     position: relative;
@@ -46,7 +46,7 @@
 
 
 
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
   .relative-l {
     position: relative;
   }

--- a/css/components/text-font.css
+++ b/css/components/text-font.css
@@ -75,7 +75,7 @@
   text-align: justify;
 }
 
-@media only screen and (min-width: var(--medium)) {
+@media only screen and (min-width: 767px) {
   .text-left-m {
     text-align: left;
   }
@@ -94,7 +94,7 @@
 }
 
 
-@media only screen and (min-width: var(--large)) {
+@media only screen and (min-width: 980px) {
   .text-left-l {
     text-align: left;
   }

--- a/css/components/typography.css
+++ b/css/components/typography.css
@@ -33,7 +33,7 @@ p {
   margin-bottom: 10px;
 }
 
-@media (max-width: var(--medium)) {
+@media (max-width: 767px) {
   h1, .h1 {
     font-size: 2.027rem;
   }

--- a/css/vars.css
+++ b/css/vars.css
@@ -15,9 +15,4 @@
   /* Buttons */
   --buttonBgColor: #33C3F0;
   --buttonBgColorHover: #1EAEDB;
-
-  /* Media Queries*/
-  --medium: 767px;
-  --large: 980px;
-  --xlarge: 1023px;
 }


### PR DESCRIPTION
1. media queries cannot be used as vars. according to the spec:
```
The var() function can not be used as property names, selectors, or anything else besides property values.
```
2. i am dumb